### PR TITLE
Add callback for when a dragged item changes indexes in the DraxList

### DIFF
--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -61,6 +61,7 @@ export const DraxList = <T extends unknown>(
 		onItemReorder,
 		id: idProp,
 		reorderable: reorderableProp,
+		onDragPositionChanged,
 		...props
 	}: PropsWithChildren<DraxListProps<T>>,
 ): ReactElement | null => {
@@ -111,6 +112,9 @@ export const DraxList = <T extends unknown>(
 
 	// Maintain cache of reordered list indexes until data updates.
 	const [originalIndexes, setOriginalIndexes] = useState<number[]>([]);
+
+	// Maintain the index the item is currently dragged to
+	const draggedToIndex = useRef<number | undefined>(undefined);
 
 	// Adjust measurements and shift value arrays as item count changes.
 	useEffect(
@@ -507,6 +511,14 @@ export const DraxList = <T extends unknown>(
 				const toPayload: ListItemPayload = receiver?.parentId === id
 					? receiver.payload
 					: fromPayload;
+
+				if (draggedToIndex.current !== undefined
+					&& toPayload.index !== draggedToIndex.current
+					&& onDragPositionChanged) {
+					onDragPositionChanged(toPayload.index);
+				}
+
+				draggedToIndex.current = toPayload.index;
 				updateShifts(fromPayload, toPayload);
 			}
 
@@ -531,6 +543,7 @@ export const DraxList = <T extends unknown>(
 			horizontal,
 			stopScroll,
 			startScroll,
+			onDragPositionChanged,
 		],
 	);
 

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -62,6 +62,8 @@ export const DraxList = <T extends unknown>(
 		id: idProp,
 		reorderable: reorderableProp,
 		onDragPositionChanged,
+		onDragStart,
+		onDragEnd,
 		...props
 	}: PropsWithChildren<DraxListProps<T>>,
 ): ReactElement | null => {
@@ -209,8 +211,14 @@ export const DraxList = <T extends unknown>(
 					dragReleasedStyle={dragReleasedStyle}
 					{...otherStyleProps}
 					payload={{ index, originalIndex }}
-					onDragStart={() => setDraggedItem(originalIndex)}
-					onDragEnd={resetDraggedItem}
+					onDragStart={(evt) => {
+						if (onDragStart) onDragStart(evt);
+						setDraggedItem(originalIndex);
+					}}
+					onDragEnd={(evt) => {
+						if (onDragEnd) onDragEnd(evt);
+						resetDraggedItem();
+					}}
 					onDragDrop={resetDraggedItem}
 					onMeasure={(measurements) => {
 						// console.log(`measuring [${index}, ${originalIndex}]: (${measurements?.x}, ${measurements?.y})`);
@@ -237,6 +245,8 @@ export const DraxList = <T extends unknown>(
 			itemStyles,
 			renderItemContent,
 			renderItemHoverContent,
+			onDragStart,
+			onDragEnd,
 		],
 	);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -809,5 +809,5 @@ export interface DraxListProps<TItem> extends Omit<FlatListProps<TItem>, 'render
 	onDragStart?: (data: DraxDragEventData) => void;
 
 	/** Called in the dragged view when drag ends not over any receiver or is cancelled */
-	onDragEnd?: (data: DraxDragEndEventData) => DraxProtocolDragEndResponse;
+	onDragEnd?: (data: DraxDragEndEventData) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -804,4 +804,10 @@ export interface DraxListProps<TItem> extends Omit<FlatListProps<TItem>, 'render
 
 	/** Callback handler for when a currently dragging list item changes position */
 	onDragPositionChanged?: (toIndex: number) => void;
+
+	/** Called in the dragged view when a drag action begins */
+	onDragStart?: (data: DraxDragEventData) => void;
+
+	/** Called in the dragged view when drag ends not over any receiver or is cancelled */
+	onDragEnd?: (data: DraxDragEndEventData) => DraxProtocolDragEndResponse;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -600,10 +600,10 @@ type AnimatedScalar = string | number;
 /** Type augmentation to allow a style to support animated values */
 export type AnimatedStyle<T> = {
 	[Key in keyof T]: T[Key] extends AnimatedScalar
-	? MaybeAnimated<T[Key]>
-	: T[Key] extends Array<infer U>
-	? Array<AnimatedStyle<U>>
-	: AnimatedStyle<T[Key]>
+		? MaybeAnimated<T[Key]>
+		: T[Key] extends Array<infer U>
+			? Array<AnimatedStyle<U>>
+			: AnimatedStyle<T[Key]>
 };
 
 /** Style for an Animated.View */

--- a/src/types.ts
+++ b/src/types.ts
@@ -600,10 +600,10 @@ type AnimatedScalar = string | number;
 /** Type augmentation to allow a style to support animated values */
 export type AnimatedStyle<T> = {
 	[Key in keyof T]: T[Key] extends AnimatedScalar
-		? MaybeAnimated<T[Key]>
-		: T[Key] extends Array<infer U>
-			? Array<AnimatedStyle<U>>
-			: AnimatedStyle<T[Key]>
+	? MaybeAnimated<T[Key]>
+	: T[Key] extends Array<infer U>
+	? Array<AnimatedStyle<U>>
+	: AnimatedStyle<T[Key]>
 };
 
 /** Style for an Animated.View */
@@ -801,4 +801,7 @@ export interface DraxListProps<TItem> extends Omit<FlatListProps<TItem>, 'render
 
 	/** Can the list be reordered by dragging items? Defaults to true if onItemReorder is set. */
 	reorderable?: boolean;
+
+	/** Callback handler for when a currently dragging list item changes position */
+	onDragPositionChanged?: (toIndex: number) => void;
 }


### PR DESCRIPTION
closes: https://github.com/nuclearpasta/react-native-drax/issues/25

I read the contributing guidelines and went ahead and made this PR since it was quick enough. Happy to chat more about reasons for wanting this and if there are better ways to do this!

This PR adds a callback `onDragPositionChanged` that is called (if supplied) when the item in a `DragList` is dragged to a new index. 

This also supports the `onDragStart` and `onDragEnd` props to be used for the `DragList`.

I tested this out in my own project to check that it behaved the correct way. Let me know if this seems ok/reasonable to you. Thanks again for the project, it is very cool!