### PR TITLE
Speed up dragging animation to be at least 60fps

### DIFF
--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -375,6 +375,7 @@ export const DraxList = <T extends unknown>(
 					Animated.timing(shift.animatedValue, {
 						duration: 200,
 						toValue: newTargetValue,
+						useNativeDriver: true,
 					}).start();
 				}
 			});

--- a/src/DraxView.tsx
+++ b/src/DraxView.tsx
@@ -392,7 +392,7 @@ export const DraxView = (
 				// Pass the event up to the Drax context.
 				handleGestureEvent(id, event);
 			},
-			33,
+			10,
 		),
 		[id, handleGestureEvent],
 	);

--- a/src/hooks/useDraxRegistry.ts
+++ b/src/hooks/useDraxRegistry.ts
@@ -496,6 +496,7 @@ const resetDragInRegistry = (
 						toValue,
 						delay: snapbackDelay,
 						duration: snapbackDuration,
+						useNativeDriver: true,
 					},
 				).start(({ finished }) => {
 					// Remove the release from tracking, regardless of whether animation finished.


### PR DESCRIPTION
Update the throttle to allow dragging to be at least 60fps.

Update Animated.timing values to `useNativeDriver: true`