### PR TITLE
Fixes for #25 and #22

### DIFF
--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -59,7 +59,7 @@ export const DraxList = <T extends unknown>(
 		renderItemContent,
 		renderItemHoverContent,
 		onItemDragStart,
-		onItemDragPositionChange: onItemDragPositionChanged,
+		onItemDragPositionChange,
 		onItemDragEnd,
 		onItemReorder,
 		id: idProp,
@@ -482,7 +482,7 @@ export const DraxList = <T extends unknown>(
 				// Reset currently dragged over position index to undefined.
 				if (draggedToIndex.current !== undefined) { // (This check is hopefully redundant.)
 					if (!totalDragEnd) {
-						onItemDragPositionChanged?.({
+						onItemDragPositionChange?.({
 							...eventData,
 							index: fromIndex,
 							item: data?.[fromOriginalIndex],
@@ -523,7 +523,7 @@ export const DraxList = <T extends unknown>(
 			calculateSnapbackTarget,
 			originalIndexes,
 			onItemDragEnd,
-			onItemDragPositionChanged,
+			onItemDragPositionChange,
 			onItemReorder,
 		],
 	);
@@ -570,7 +570,7 @@ export const DraxList = <T extends unknown>(
 				// Check and update currently dragged over position index.
 				const toIndex = toPayload?.index;
 				if (toIndex !== draggedToIndex.current) {
-					onItemDragPositionChanged?.({
+					onItemDragPositionChange?.({
 						...eventData,
 						toIndex,
 						index: fromPayload.index,
@@ -606,7 +606,7 @@ export const DraxList = <T extends unknown>(
 			horizontal,
 			stopScroll,
 			startScroll,
-			onItemDragPositionChanged,
+			onItemDragPositionChange,
 		],
 	);
 

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -30,9 +30,9 @@ import {
 	DraxMonitorDragDropEventData,
 	DraxMonitorEndEventData,
 	DraxViewRegistration,
-	DraxEventViewData,
 	DraxProtocolDragEndResponse,
 	DraxSnapbackTargetPreset,
+	isWithCancelledFlag,
 } from './types';
 import { defaultListItemLongPressDelay } from './params';
 
@@ -58,12 +58,12 @@ export const DraxList = <T extends unknown>(
 		itemStyles,
 		renderItemContent,
 		renderItemHoverContent,
+		onItemDragStart,
+		onItemDragPositionChange: onItemDragPositionChanged,
+		onItemDragEnd,
 		onItemReorder,
 		id: idProp,
 		reorderable: reorderableProp,
-		onDragPositionChanged,
-		onDragStart,
-		onDragEnd,
 		...props
 	}: PropsWithChildren<DraxListProps<T>>,
 ): ReactElement | null => {
@@ -115,7 +115,7 @@ export const DraxList = <T extends unknown>(
 	// Maintain cache of reordered list indexes until data updates.
 	const [originalIndexes, setOriginalIndexes] = useState<number[]>([]);
 
-	// Maintain the index the item is currently dragged to
+	// Maintain the index the item is currently dragged to.
 	const draggedToIndex = useRef<number | undefined>(undefined);
 
 	// Adjust measurements, registrations, and shift value arrays as item count changes.
@@ -211,14 +211,7 @@ export const DraxList = <T extends unknown>(
 					dragReleasedStyle={dragReleasedStyle}
 					{...otherStyleProps}
 					payload={{ index, originalIndex }}
-					onDragStart={(evt) => {
-						if (onDragStart) onDragStart(evt);
-						setDraggedItem(originalIndex);
-					}}
-					onDragEnd={(evt) => {
-						if (onDragEnd) onDragEnd(evt);
-						resetDraggedItem();
-					}}
+					onDragEnd={resetDraggedItem}
 					onDragDrop={resetDraggedItem}
 					onMeasure={(measurements) => {
 						// console.log(`measuring [${index}, ${originalIndex}]: (${measurements?.x}, ${measurements?.y})`);
@@ -240,13 +233,10 @@ export const DraxList = <T extends unknown>(
 		[
 			originalIndexes,
 			getShiftTransform,
-			setDraggedItem,
 			resetDraggedItem,
 			itemStyles,
 			renderItemContent,
 			renderItemHoverContent,
-			onDragStart,
-			onDragEnd,
 		],
 	);
 
@@ -452,48 +442,81 @@ export const DraxList = <T extends unknown>(
 		[horizontal, itemCount, originalIndexes],
 	);
 
-	// Stop scrolling, and potentially update shifts and reorder data.
-	const handleInternalDragEnd = useCallback(
+
+	/*
+	 * Stop auto-scrolling, and potentially update shifts and reorder data.
+	 *
+	 * This is a multi-purpose monitor callback handler for:
+	 *
+	 *  onMonitorDragExit: Monitor drag exits to stop scrolling and update shifts.
+	 *
+	 *  onMonitorDragEnd: Monitor drag ends to stop scrolling, update shifts, and possibly reorder.
+	 *  This addresses the Android case where if we drag a list item and auto-scroll
+	 *  too far, the drag gets cancelled.
+	 *
+	 *  onMonitorDragDrop: Monitor drag drops to stop scrolling, update shifts, and possibly reorder.
+	 */
+	const handleDragEnd = useCallback(
 		(
-			dragged?: DraxEventViewData,
-			receiver?: DraxEventViewData,
+			eventData: DraxMonitorEventData | DraxMonitorEndEventData | DraxMonitorDragDropEventData,
 		): DraxProtocolDragEndResponse => {
 			// Always stop auto-scroll on drag end.
 			scrollStateRef.current = AutoScrollDirection.None;
 			stopScroll();
 
-			// If the list is reorderable, handle shifts and reordering.
-			if (reorderable) {
+			const { dragged, receiver } = eventData;
+
+			// Check if we need to handle this drag end.
+			if (reorderable && dragged.parentId === id) {
 				// Determine list indexes of dragged/received items, if any.
-				const fromPayload = dragged && (dragged.parentId === id)
-					? (dragged.payload as ListItemPayload)
-					: undefined;
-				const toPayload = (fromPayload !== undefined && receiver && receiver.parentId === id)
+				const fromPayload = dragged.payload as ListItemPayload;
+				const toPayload = receiver?.parentId === id
 					? (receiver.payload as ListItemPayload)
 					: undefined;
 
-				if (fromPayload !== undefined) {
-					// If dragged item was ours, reset shifts.
-					resetShifts();
-					if (toPayload !== undefined) {
-						// If dragged item and received item were ours, reorder data.
-						// console.log(`moving ${fromPayload.index} -> ${toPayload.index}`);
-						const snapbackTarget = calculateSnapbackTarget(fromPayload, toPayload);
-						const { index: fromIndex, originalIndex: fromOriginalIndex } = fromPayload;
-						const { index: toIndex, originalIndex: toOriginalIndex } = toPayload;
-						if (data) {
-							const newOriginalIndexes = originalIndexes.slice();
-							newOriginalIndexes.splice(toIndex, 0, newOriginalIndexes.splice(fromIndex, 1)[0]);
-							setOriginalIndexes(newOriginalIndexes);
-							onItemReorder?.({
-								fromIndex,
-								toIndex,
-								fromItem: data[fromOriginalIndex],
-								toItem: data[toOriginalIndex],
-							});
-						}
-						return snapbackTarget;
+				const { index: fromIndex, originalIndex: fromOriginalIndex } = fromPayload;
+				const { index: toIndex, originalIndex: toOriginalIndex } = toPayload ?? {};
+				const toItem = toOriginalIndex ? data?.[toOriginalIndex] : undefined;
+
+				// Reset all shifts and call callback, regardless of whether toPayload exists.
+				resetShifts();
+				onItemDragEnd?.({
+					...eventData,
+					toIndex,
+					toItem,
+					cancelled: isWithCancelledFlag(eventData) ? eventData.cancelled : false,
+					index: fromIndex,
+					item: data?.[fromOriginalIndex],
+				});
+
+				// Reset currently dragged over position index to undefined.
+				if (draggedToIndex.current !== undefined) { // (This check is hopefully redundant.)
+					onItemDragPositionChanged?.({
+						...eventData,
+						index: fromIndex,
+						item: data?.[fromOriginalIndex],
+						toIndex: undefined,
+						previousIndex: draggedToIndex.current,
+					});
+					draggedToIndex.current = undefined;
+				}
+
+				if (toPayload !== undefined) {
+					// If dragged item and received item were ours, reorder data.
+					// console.log(`moving ${fromPayload.index} -> ${toPayload.index}`);
+					const snapbackTarget = calculateSnapbackTarget(fromPayload, toPayload);
+					if (data) {
+						const newOriginalIndexes = originalIndexes.slice();
+						newOriginalIndexes.splice(toIndex!, 0, newOriginalIndexes.splice(fromIndex, 1)[0]);
+						setOriginalIndexes(newOriginalIndexes);
+						onItemReorder?.({
+							fromIndex,
+							fromItem: data[fromOriginalIndex],
+							toIndex: toIndex!,
+							toItem: data[toOriginalIndex!],
+						});
 					}
+					return snapbackTarget;
 				}
 			}
 
@@ -507,30 +530,66 @@ export const DraxList = <T extends unknown>(
 			resetShifts,
 			calculateSnapbackTarget,
 			originalIndexes,
+			onItemDragEnd,
+			onItemDragPositionChanged,
 			onItemReorder,
+		],
+	);
+
+	// Monitor drag starts to handle callbacks.
+	const onMonitorDragStart = useCallback(
+		(eventData: DraxMonitorEventData) => {
+			const { dragged } = eventData;
+			// First, check if we need to do anything.
+			if (reorderable && dragged.parentId === id) {
+				// One of our list items is starting to be dragged.
+				const { index, originalIndex }: ListItemPayload = dragged.payload;
+				setDraggedItem(originalIndex);
+				onItemDragStart?.({
+					...eventData,
+					index,
+					item: data?.[originalIndex],
+				});
+			}
+		},
+		[
+			id,
+			reorderable,
+			data,
+			setDraggedItem,
+			onItemDragStart,
 		],
 	);
 
 	// Monitor drags to react with item shifts and auto-scrolling.
 	const onMonitorDragOver = useCallback(
-		({ dragged, receiver, monitorOffsetRatio }: DraxMonitorEventData) => {
+		(eventData: DraxMonitorEventData) => {
+			const { dragged, receiver, monitorOffsetRatio } = eventData;
 			// First, check if we need to shift items.
 			if (reorderable && dragged.parentId === id) {
 				// One of our list items is being dragged.
 				const fromPayload: ListItemPayload = dragged.payload;
-				// Find its current index in the list for the purpose of shifting.
-				const toPayload: ListItemPayload = receiver?.parentId === id
-					? receiver.payload
-					: fromPayload;
 
-				if (draggedToIndex.current !== undefined
-					&& toPayload.index !== draggedToIndex.current
-					&& onDragPositionChanged) {
-					onDragPositionChanged(toPayload.index);
+				// Find its current position index in the list, if any.
+				const toPayload: ListItemPayload | undefined = receiver?.parentId === id
+					? receiver.payload
+					: undefined;
+
+				// Check and update currently dragged over position index.
+				const toIndex = toPayload?.index;
+				if (toIndex !== draggedToIndex.current) {
+					onItemDragPositionChanged?.({
+						...eventData,
+						toIndex,
+						index: fromPayload.index,
+						item: data?.[fromPayload.originalIndex],
+						previousIndex: draggedToIndex.current,
+					});
+					draggedToIndex.current = toIndex;
 				}
 
-				draggedToIndex.current = toPayload.index;
-				updateShifts(fromPayload, toPayload);
+				// Update shift transforms for items in the list.
+				updateShifts(fromPayload, toPayload ?? fromPayload);
 			}
 
 			// Next, see if we need to auto-scroll.
@@ -550,34 +609,13 @@ export const DraxList = <T extends unknown>(
 		[
 			id,
 			reorderable,
+			data,
 			updateShifts,
 			horizontal,
 			stopScroll,
 			startScroll,
-			onDragPositionChanged,
+			onItemDragPositionChanged,
 		],
-	);
-
-	// Monitor drag exits to stop scrolling and update shifts.
-	const onMonitorDragExit = useCallback(
-		({ dragged }: DraxMonitorEventData) => handleInternalDragEnd(dragged),
-		[handleInternalDragEnd],
-	);
-
-	/*
-	 * Monitor drag ends to stop scrolling, update shifts, and possibly reorder.
-	 * This addresses the Android case where if we drag a list item and auto-scroll
-	 * too far, the drag gets cancelled.
-	 */
-	const onMonitorDragEnd = useCallback(
-		({ dragged, receiver }: DraxMonitorEndEventData) => handleInternalDragEnd(dragged, receiver),
-		[handleInternalDragEnd],
-	);
-
-	// Monitor drag drops to stop scrolling, update shifts, and possibly reorder.
-	const onMonitorDragDrop = useCallback(
-		({ dragged, receiver }: DraxMonitorDragDropEventData) => handleInternalDragEnd(dragged, receiver),
-		[handleInternalDragEnd],
 	);
 
 	return id ? (
@@ -586,10 +624,11 @@ export const DraxList = <T extends unknown>(
 			style={style}
 			scrollPositionRef={scrollPositionRef}
 			onMeasure={onMeasureContainer}
+			onMonitorDragStart={onMonitorDragStart}
 			onMonitorDragOver={onMonitorDragOver}
-			onMonitorDragExit={onMonitorDragExit}
-			onMonitorDragEnd={onMonitorDragEnd}
-			onMonitorDragDrop={onMonitorDragDrop}
+			onMonitorDragExit={handleDragEnd}
+			onMonitorDragEnd={handleDragEnd}
+			onMonitorDragDrop={handleDragEnd}
 		>
 			<DraxSubprovider parent={{ id, nodeHandleRef }}>
 				<FlatList


### PR DESCRIPTION
- Implements `onMonitorDragStart` (#22)
- Adds new `DraxList` list item drag lifecycle callbacks: `onItemDragStart`, `onItemDragPositionChange`, `onItemDragEnd` (#25) 