### PR TITLE
Check for an individual item 'draggable' prop

### DIFF
--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -215,7 +215,7 @@ export const DraxList = <T extends unknown>(
 					payload={{ index, originalIndex }}
 					onDragEnd={resetDraggedItem}
 					onDragDrop={resetDraggedItem}
-					draggable={itemsDraggable}
+					draggable={info.items.draggable ?? itemsDraggable}
 					onMeasure={(measurements) => {
 						// console.log(`measuring [${index}, ${originalIndex}]: (${measurements?.x}, ${measurements?.y})`);
 						itemMeasurementsRef.current[originalIndex] = measurements;

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -215,7 +215,7 @@ export const DraxList = <T extends unknown>(
 					payload={{ index, originalIndex }}
 					onDragEnd={resetDraggedItem}
 					onDragDrop={resetDraggedItem}
-					draggable={info.items.draggable ?? itemsDraggable}
+					draggable={info.item.draggable ?? itemsDraggable}
 					onMeasure={(measurements) => {
 						// console.log(`measuring [${index}, ${originalIndex}]: (${measurements?.x}, ${measurements?.y})`);
 						itemMeasurementsRef.current[originalIndex] = measurements;


### PR DESCRIPTION
This PR adds a check in `DraxList` for an individual list item key `draggable`. This would allow individual list items to be prevented from dragging, instead of all or none (`itemsDraggable`). If the `draggable` key doesn't exist, it will fall back to `itemsDraggable`.