### PR TITLE
Use remove() on effect instead of removeListener

### DIFF
--- a/src/DraxView.tsx
+++ b/src/DraxView.tsx
@@ -455,8 +455,8 @@ export const DraxView = (
 				// console.log(`Dimensions changed to ${width}/${height}`);
 				setTimeout(measureWithHandler, 100);
 			};
-			Dimensions.addEventListener('change', handler);
-			return () => Dimensions.removeEventListener('change', handler);
+			const listener = Dimensions.addEventListener('change', handler);
+			return () => listener.remove();
 		},
 		[measureWithHandler],
 	);


### PR DESCRIPTION
Silences warnings:

```
 WARN  EventEmitter.removeListener('change', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`. 
```