### PR TITLE
Allow overriding DraxProvider style.

### DIFF
--- a/src/DraxProvider.tsx
+++ b/src/DraxProvider.tsx
@@ -20,7 +20,7 @@ import {
 } from './types';
 import { getRelativePosition } from './math';
 
-export const DraxProvider: FunctionComponent<DraxProviderProps> = ({ debug = false, children }) => {
+export const DraxProvider: FunctionComponent<DraxProviderProps> = ({ debug = false, style, children }) => {
 	const {
 		getViewState,
 		getTrackingStatus,
@@ -776,7 +776,7 @@ export const DraxProvider: FunctionComponent<DraxProviderProps> = ({ debug = fal
 	return (
 		<DraxContext.Provider value={contextValue}>
 			<View
-				style={styles.provider}
+				style={[styles.provider, style]}
 				ref={setRootNodeHandleRef}
 			>
 				{children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -583,6 +583,9 @@ export interface DraxContextValue {
 /** Optional props that can be passed to a DraxProvider to modify its behavior */
 export interface DraxProviderProps {
 	debug?: boolean;
+
+	/** Drax parent view style */
+	style?: StyleProp<ViewStyle>;
 }
 
 /** Props that are passed to a DraxSubprovider, used internally for nesting views */


### PR DESCRIPTION
For some scenarios, it may be beneficial to override the flex:1 to allow wrapping a dynamic container without eating all possible space. I.e. let the contents decide the size.

To allow configuration of this, we might as well pass through styling to allow even more configurations.

---

Big thanks for you project! I've only verified these changes in my own project, but it's also a fairly trivial change!

Let me know if you need anything else, or have opinions about the change request.

// Patrick