### PR TITLE
New Architecture Support - measureLayout() is obsolete with native node handlers

### DIFF
--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -16,7 +16,6 @@ import {
 	NativeSyntheticEvent,
 	FlatList,
 	Animated,
-	findNodeHandle,
 	StyleSheet,
 } from 'react-native';
 
@@ -90,11 +89,8 @@ const DraxListUnforwarded = <T extends unknown>(
 	// The unique identifer for this list's Drax view.
 	const id = useDraxId(idProp);
 
-	// FlatList, used for scrolling.
+	// FlatList, used for scrolling and measuring children
 	const flatListRef = useRef<FlatList<T> | null>(null);
-
-	// FlatList node handle, used for measuring children.
-	const nodeHandleRef = useRef<number | null>(null);
 
 	// Container view measurements, for scrolling by percentage.
 	const containerMeasurementsRef = useRef<DraxViewMeasurements | undefined>(undefined);
@@ -293,7 +289,6 @@ const DraxListUnforwarded = <T extends unknown>(
 	const setFlatListRefs = useCallback(
 		(ref) => {
 			flatListRef.current = ref;
-			nodeHandleRef.current = ref && findNodeHandle(ref);
 			if (forwardedRef) {
 				if (typeof forwardedRef === 'function') {
 					forwardedRef(ref);
@@ -689,7 +684,7 @@ const DraxListUnforwarded = <T extends unknown>(
 			onMonitorDragEnd={onMonitorDragEnd}
 			onMonitorDragDrop={onMonitorDragDrop}
 		>
-			<DraxSubprovider parent={{ id, nodeHandleRef }}>
+			<DraxSubprovider parent={{ id, nodeViewRef: flatListRef }}>
 				<FlatList
 					{...flatListProps}
 					style={flatListStyle}

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -288,7 +288,7 @@ const DraxListUnforwarded = <T extends unknown>(
 	// Set FlatList and node handle refs.
 	const setFlatListRefs = useCallback(
 		(ref) => {
-			flatListRef.current = ref?.getNativeScrollRef?.();
+			flatListRef.current = ref;
 			if (forwardedRef) {
 				if (typeof forwardedRef === 'function') {
 					forwardedRef(ref);
@@ -684,7 +684,10 @@ const DraxListUnforwarded = <T extends unknown>(
 			onMonitorDragEnd={onMonitorDragEnd}
 			onMonitorDragDrop={onMonitorDragDrop}
 		>
-			<DraxSubprovider parent={{ id, viewRef: flatListRef }}>
+			<DraxSubprovider parent={{ id, viewRef: {
+				//@ts-ignore
+				current: flatListRef.current?.getNativeScrollRef()
+			} }}>
 				<FlatList
 					{...flatListProps}
 					style={flatListStyle}

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -288,7 +288,7 @@ const DraxListUnforwarded = <T extends unknown>(
 	// Set FlatList and node handle refs.
 	const setFlatListRefs = useCallback(
 		(ref) => {
-			flatListRef.current = ref.getNativeScrollRef();
+			flatListRef.current = ref?.getNativeScrollRef?.();
 			if (forwardedRef) {
 				if (typeof forwardedRef === 'function') {
 					forwardedRef(ref);

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -288,7 +288,7 @@ const DraxListUnforwarded = <T extends unknown>(
 	// Set FlatList and node handle refs.
 	const setFlatListRefs = useCallback(
 		(ref) => {
-			flatListRef.current = ref;
+			flatListRef.current = ref.getNativeScrollRef();
 			if (forwardedRef) {
 				if (typeof forwardedRef === 'function') {
 					forwardedRef(ref);

--- a/src/DraxList.tsx
+++ b/src/DraxList.tsx
@@ -684,7 +684,7 @@ const DraxListUnforwarded = <T extends unknown>(
 			onMonitorDragEnd={onMonitorDragEnd}
 			onMonitorDragDrop={onMonitorDragDrop}
 		>
-			<DraxSubprovider parent={{ id, nodeViewRef: flatListRef }}>
+			<DraxSubprovider parent={{ id, viewRef: flatListRef }}>
 				<FlatList
 					{...flatListProps}
 					style={flatListStyle}

--- a/src/DraxProvider.tsx
+++ b/src/DraxProvider.tsx
@@ -3,7 +3,7 @@ import React, {
 	ReactNodeArray,
 	useRef,
 } from 'react';
-import { View, StyleSheet, findNodeHandle } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { State } from 'react-native-gesture-handler';
 
 import { useDraxState, useDraxRegistry } from './hooks';
@@ -50,7 +50,7 @@ export const DraxProvider = ({
 		unregisterView,
 	} = useDraxRegistry(dispatch);
 
-	const rootNodeHandleRef = useRef<number | null>(null);
+	const rootViewRef = useRef<View | null>(null);
 
 	const handleGestureStateChange = useCallback(
 		(id: string, event: DraxGestureStateChangeEvent) => {
@@ -742,7 +742,7 @@ export const DraxProvider = ({
 		updateViewMeasurements,
 		handleGestureStateChange,
 		handleGestureEvent,
-		rootNodeHandleRef,
+		rootViewRef,
 	};
 
 	const hoverViews: ReactNodeArray = [];
@@ -769,18 +769,11 @@ export const DraxProvider = ({
 		}
 	});
 
-	const setRootNodeHandleRef = useCallback(
-		(ref: View | null) => {
-			rootNodeHandleRef.current = ref && findNodeHandle(ref);
-		},
-		[],
-	);
-
 	return (
 		<DraxContext.Provider value={contextValue}>
 			<View
 				style={style}
-				ref={setRootNodeHandleRef}
+				ref={rootViewRef}
 			>
 				{children}
 				<View

--- a/src/DraxScrollView.tsx
+++ b/src/DraxScrollView.tsx
@@ -10,7 +10,6 @@ import {
 	ScrollView,
 	NativeSyntheticEvent,
 	NativeScrollEvent,
-	findNodeHandle,
 } from 'react-native';
 
 import { DraxView } from './DraxView';
@@ -53,11 +52,8 @@ const DraxScrollViewUnforwarded = (
 	// The unique identifer for this view.
 	const id = useDraxId(idProp);
 
-	// Scrollable view, used for scrolling.
+	// Scrollable view, used for scrolling and measuring children
 	const scrollRef = useRef<ScrollView | null>(null);
-
-	// ScrollView node handle, used for measuring children.
-	const nodeHandleRef = useRef<number | null>(null);
 
 	// Container view measurements, for scrolling by percentage.
 	const containerMeasurementsRef = useRef<DraxViewMeasurements | undefined>(undefined);
@@ -215,7 +211,6 @@ const DraxScrollViewUnforwarded = (
 	const setScrollViewRefs = useCallback(
 		(ref: ScrollView | null) => {
 			scrollRef.current = ref;
-			nodeHandleRef.current = ref && findNodeHandle(ref);
 			if (forwardedRef) {
 				if (typeof forwardedRef === 'function') {
 					forwardedRef(ref);
@@ -258,7 +253,7 @@ const DraxScrollViewUnforwarded = (
 			onMonitorDragEnd={resetScroll}
 			onMonitorDragDrop={resetScroll}
 		>
-			<DraxSubprovider parent={{ id, nodeHandleRef }}>
+			<DraxSubprovider parent={{ id, nodeViewRef: scrollRef }}>
 				<ScrollView
 					{...scrollViewProps}
 					ref={setScrollViewRefs}

--- a/src/DraxScrollView.tsx
+++ b/src/DraxScrollView.tsx
@@ -253,7 +253,7 @@ const DraxScrollViewUnforwarded = (
 			onMonitorDragEnd={resetScroll}
 			onMonitorDragDrop={resetScroll}
 		>
-			<DraxSubprovider parent={{ id, nodeViewRef: scrollRef }}>
+			<DraxSubprovider parent={{ id, viewRef: scrollRef }}>
 				<ScrollView
 					{...scrollViewProps}
 					ref={setScrollViewRefs}

--- a/src/DraxView.tsx
+++ b/src/DraxView.tsx
@@ -156,7 +156,7 @@ export const DraxView = (
 	const parentId = parent?.id;
 
 	// Identify parent node handle ref.
-	const parentViewRef = parent ? parent.nodeViewRef : rootViewRef;
+	const parentViewRef = parent ? parent.viewRef : rootViewRef;
 
 	// Register and unregister with Drax context when necessary.
 	useEffect(
@@ -572,7 +572,7 @@ export const DraxView = (
 			if (isParent) {
 				// This is a Drax parent, so wrap children in subprovider.
 				content = (
-					<DraxSubprovider parent={{ id, nodeViewRef: viewRef }}>
+					<DraxSubprovider parent={{ id, viewRef }}>
 						{content}
 					</DraxSubprovider>
 				);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 import { RefObject, ReactNode } from 'react';
 import {
-	ViewProps,
 	Animated,
-	FlatListProps,
+	View,
+	ViewProps,
 	ViewStyle,
 	StyleProp,
+	FlatList,
+	FlatListProps,
+	ScrollView,
 	ScrollViewProps,
 	ListRenderItemInfo,
 } from 'react-native';
@@ -574,7 +577,7 @@ export interface DraxContextValue {
 	handleGestureEvent: (id: string, event: DraxGestureEvent) => void;
 
 	/** Root node handle ref for the Drax provider, for measuring non-parented views in relation to */
-	rootNodeHandleRef: RefObject<number | null>;
+	rootViewRef: RefObject<View | null>;
 
 	/** Drax parent view for all views under this context, when nesting */
 	parent?: DraxParentView;
@@ -604,7 +607,7 @@ export interface DraxParentView {
 	/** Drax view id of the parent */
 	id: string;
 	/** Ref to node handle of the parent, for measuring relative to */
-	nodeHandleRef: RefObject<number | null>;
+	nodeViewRef: RefObject<FlatList | ScrollView | View | null>;
 }
 
 /** Function that receives a Drax view measurement */

--- a/src/types.ts
+++ b/src/types.ts
@@ -576,7 +576,7 @@ export interface DraxContextValue {
 	/** Handle gesture event for a registered Drax view */
 	handleGestureEvent: (id: string, event: DraxGestureEvent) => void;
 
-	/** Root node handle ref for the Drax provider, for measuring non-parented views in relation to */
+	/** Root View ref for the Drax provider, for measuring non-parented views in relation to */
 	rootViewRef: RefObject<View | null>;
 
 	/** Drax parent view for all views under this context, when nesting */
@@ -606,8 +606,8 @@ export interface DraxViewRegistration {
 export interface DraxParentView {
 	/** Drax view id of the parent */
 	id: string;
-	/** Ref to node handle of the parent, for measuring relative to */
-	nodeViewRef: RefObject<FlatList | ScrollView | View | null>;
+	/** View Ref of the parent, for measuring relative to */
+	viewRef: RefObject<FlatList | ScrollView | View | null>;
 }
 
 /** Function that receives a Drax view measurement */


### PR DESCRIPTION
## Hello

### This PR fixes: 

- #174 
- #171 

---- 
### The Problem
**SOURCE:** [React Native Docs - Direct Manipulation: measureLayout()](https://reactnative.dev/docs/direct-manipulation#measurelayoutrelativetonativecomponentref-onsuccess-onfail)
<img width="550" alt="image" src="https://github.com/user-attachments/assets/9e67562f-885d-4727-9199-4d83375c6ef8">

----

### Conclusion 

On the new architecture, `measureLayout()` with a `relativeToNativeNode` handler (instead of reference) is **OBSOLETE**

I also opened a PR to update React Native Docs (which was already merged):

- https://github.com/facebook/react-native-website/pull/4277

--- 

While passing a view ref will make it **WORK** with the new architecture, [we should still use the new architecture capabilities](https://reactnative.dev/docs/the-new-architecture/landing-page#synchronous-layout-and-effects).

From my testing this works fine, but I would love if the community reviews it and tests it.

Let me know if anyone needs help to test those changes!

Cheers 🍻
