### PR TITLE
Replace absoluteFillObject with absoluteFill

### DIFF
--- a/src/HoverLayer.tsx
+++ b/src/HoverLayer.tsx
@@ -152,7 +152,7 @@ export const HoverLayer = memo(
 
 const styles = StyleSheet.create({
   container: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     // Default hidden — useAnimatedStyle overrides to opacity:1 when dragging.
     // Prevents a one-frame flash on first mount before the animated style evaluates.
     opacity: 0,


### PR DESCRIPTION
Hey thanks for this awesome library.

I ran into some issues with the HoverLayer after upgrading to React Native 0.86, looks like `StyleSheet.absoluteFillObject` has been removed.

It's present in [0.84](https://reactnative.dev/docs/0.84/stylesheet#absolutefill), but removed in [0.85](https://reactnative.dev/docs/0.85/stylesheet#absolutefill)

As such, this PR changes the `HoverLayer` to use `StyleSheet.absoluteFill` instead.