### PR TITLE
feat(DraxView): add per-axis drag activation offsets

### DIFF
--- a/docs-site/docs/api/components/drax-view.mdx
+++ b/docs-site/docs/api/components/drax-view.mdx
@@ -46,8 +46,35 @@ import { DraxView } from 'react-native-drax';
 | `lockDragXPosition` | `boolean` | `false` | Lock horizontal drag movement |
 | `lockDragYPosition` | `boolean` | `false` | Lock vertical drag movement |
 | `dragActivationFailOffset` | `number` | — | Cancel drag if finger moves more than this (px) during long press |
+| `dragActivationOffsetX` | `number \| [number, number]` | — | Minimum horizontal travel (px) before the drag activates (`activeOffsetX`) |
+| `dragActivationOffsetY` | `number \| [number, number]` | — | Vertical counterpart of `dragActivationOffsetX` (`activeOffsetY`) |
+| `dragActivationFailOffsetX` | `number \| [number, number]` | — | Per-axis `dragActivationFailOffset`; takes precedence on its own axis |
+| `dragActivationFailOffsetY` | `number \| [number, number]` | — | See `dragActivationFailOffsetX` |
 | `capacity` | `number` | — | Max items this view can receive (auto-rejects when full) |
 | `rejectOwnChildren` | `boolean` | `false` | Don't receive drags from own children |
+
+### Activating a drag by direction
+
+`longPressDelay` activates the pan after its delay **regardless of movement**, so
+a stationary press starts a drag. That is a problem when the draggable view also
+hosts a long-press context menu, or sits in a scrollable list: any delay short
+enough to feel responsive cancels the menu, and any delay long enough to avoid it
+loses the drag.
+
+When every meaningful drop is on one axis, the offsets can separate the gestures
+instead of a timer:
+
+```jsx
+<DraxView
+  longPressDelay={0}              // a stationary press never starts a drag
+  dragActivationOffsetX={[-15, 15]}    // only a sideways pull picks the view up
+  dragActivationFailOffsetY={[-15, 15]} // vertical travel returns the gesture to the list
+  payload={item}
+/>
+```
+
+A press that doesn't move leaves the context menu to open, a vertical drag scrolls
+the list, and a horizontal drag starts the drag.
 
 ## Drag Callbacks
 

--- a/src/DraxView.tsx
+++ b/src/DraxView.tsx
@@ -88,6 +88,10 @@ const DRAX_PROP_KEYS: ReadonlySet<string> = new Set([
   'otherDraggingWithoutReceiverStyle',
   'dragHandle',
   'dragActivationFailOffset',
+  'dragActivationOffsetX',
+  'dragActivationOffsetY',
+  'dragActivationFailOffsetX',
+  'dragActivationFailOffsetY',
   'collisionAlgorithm',
   'scrollHorizontal',
 ]);
@@ -355,7 +359,13 @@ export const DraxView = memo((props: DraxViewProps): ReactNode => {
     lockDragYPosition,
     dragBoundsSV,
     props.dragActivationFailOffset,
-    scrollHorizontal
+    scrollHorizontal,
+    {
+      offsetX: props.dragActivationOffsetX,
+      offsetY: props.dragActivationOffsetY,
+      failOffsetX: props.dragActivationFailOffsetX,
+      failOffsetY: props.dragActivationFailOffsetY,
+    }
   );
 
   // ── Animated styles ────────────────────────────────────────────────

--- a/src/compat/types.ts
+++ b/src/compat/types.ts
@@ -28,6 +28,11 @@ export interface DraxPanGestureConfig {
    *  Prevents accidental drags when the user is trying to scroll. */
   failOffsetX?: number | [number, number];
   failOffsetY?: number | [number, number];
+  /** Minimum travel on an axis before the gesture activates. Lets a drag be
+   *  told apart from a stationary press or a scroll by direction rather than
+   *  by a long-press delay. */
+  activeOffsetX?: number | [number, number];
+  activeOffsetY?: number | [number, number];
   onActivate: (event: DraxPanEvent) => void;
   onUpdate: (event: DraxPanEvent) => void;
   onDeactivate: (event: DraxPanEvent) => void;

--- a/src/compat/useDraxPanGesture.ts
+++ b/src/compat/useDraxPanGesture.ts
@@ -30,6 +30,8 @@ function useDraxPanGestureV3(config: DraxPanGestureConfig): DraxPanGesture {
   };
   if (config.failOffsetX !== undefined) panConfig.failOffsetX = config.failOffsetX;
   if (config.failOffsetY !== undefined) panConfig.failOffsetY = config.failOffsetY;
+  if (config.activeOffsetX !== undefined) panConfig.activeOffsetX = config.activeOffsetX;
+  if (config.activeOffsetY !== undefined) panConfig.activeOffsetY = config.activeOffsetY;
   return rngh.usePanGesture(panConfig);
 }
 
@@ -78,6 +80,8 @@ function useDraxPanGestureV2(config: DraxPanGestureConfig): DraxPanGesture {
       .shouldCancelWhenOutside(config.shouldCancelWhenOutside);
     if (config.failOffsetX !== undefined) g = g.failOffsetX(config.failOffsetX);
     if (config.failOffsetY !== undefined) g = g.failOffsetY(config.failOffsetY);
+    if (config.activeOffsetX !== undefined) g = g.activeOffsetX(config.activeOffsetX);
+    if (config.activeOffsetY !== undefined) g = g.activeOffsetY(config.activeOffsetY);
     return g
       .onStart((event: DraxPanEvent) => {
         'worklet';

--- a/src/hooks/useDragGesture.ts
+++ b/src/hooks/useDragGesture.ts
@@ -25,7 +25,15 @@ export const useDragGesture = (
   lockDragYPosition?: boolean,
   dragBoundsSV?: SharedValue<{ x: number; y: number; width: number; height: number } | null>,
   dragActivationFailOffset?: number,
-  scrollHorizontal?: boolean
+  scrollHorizontal?: boolean,
+  /** Per-axis activation, for telling a drag apart by direction rather than
+   *  by time. See `dragActivationOffsetX` in types.ts. */
+  dragActivationOffsets?: {
+    offsetX?: number | [number, number];
+    offsetY?: number | [number, number];
+    failOffsetX?: number | [number, number];
+    failOffsetY?: number | [number, number];
+  }
 ) => {
   const {
     draggedIdSV,
@@ -58,14 +66,21 @@ export const useDragGesture = (
     ? [-dragActivationFailOffset, dragActivationFailOffset] as [number, number]
     : undefined;
 
+  // Per-axis values win over the symmetric shorthand on their own axis, so a
+  // caller can fail the drag on one axis while activating it on the other.
+  const failOffsetX = dragActivationOffsets?.failOffsetX ?? failOffset;
+  const failOffsetY = dragActivationOffsets?.failOffsetY ?? failOffset;
+
   const gesture = useDraxPanGesture({
     enabledSV,
     longPressDelaySV,
     maxPointers: 1,
     shouldCancelWhenOutside: false,
     touchAction,
-    failOffsetX: failOffset,
-    failOffsetY: failOffset,
+    activeOffsetX: dragActivationOffsets?.offsetX,
+    activeOffsetY: dragActivationOffsets?.offsetY,
+    failOffsetX,
+    failOffsetY,
     onActivate: (event) => {
       'worklet';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,24 @@ export interface DraxViewProps
    *  Prevents accidental drags when the user is trying to scroll.
    *  Can be a number (symmetric) or [min, max] tuple per axis. */
   dragActivationFailOffset?: number;
+  /** Minimum horizontal travel (px) before the drag activates. Maps to
+   *  gesture-handler's `activeOffsetX`.
+   *
+   *  Use this to tell a drag apart by *direction* rather than by time. With
+   *  `longPressDelay: 0` and this set, a stationary press never starts a
+   *  drag — so a long-press context menu underneath the view still opens —
+   *  and pairing it with `dragActivationFailOffsetY` leaves vertical
+   *  scrolling to the list the view sits in.
+   *
+   *  Can be a number (symmetric) or [min, max] tuple. */
+  dragActivationOffsetX?: number | [number, number];
+  /** Vertical counterpart of `dragActivationOffsetX` (`activeOffsetY`). */
+  dragActivationOffsetY?: number | [number, number];
+  /** Per-axis `dragActivationFailOffset`. Takes precedence over it on its
+   *  own axis, so one axis can fail the drag while the other activates it. */
+  dragActivationFailOffsetX?: number | [number, number];
+  /** See `dragActivationFailOffsetX`. */
+  dragActivationFailOffsetY?: number | [number, number];
 
   /** Hint that this view is inside a horizontal scroll container.
    *  On mobile web, sets `touch-action: pan-x` so the browser allows


### PR DESCRIPTION
Adds four optional props — `dragActivationOffsetX` / `dragActivationOffsetY` (mapping to gesture-handler's `activeOffsetX` / `activeOffsetY`) and per-axis `dragActivationFailOffsetX` / `dragActivationFailOffsetY` — so a drag can be told apart by **direction** rather than by a long-press delay.

Happy to move this to an issue for discussion first if you'd prefer; CONTRIBUTING asks for that on non-trivial changes and I wasn't sure which side of that line this falls on.

## The problem

`longPressDelay` maps to `activateAfterLongPress`, which activates the pan after its delay **regardless of movement** — so a stationary press starts a drag.

That's fine in isolation, but it conflicts when the draggable view also hosts a long-press context menu. On iOS that's a `UIContextMenuInteraction` at ~500ms; when the pan activates first it cancels the UIKit touches and the menu never opens. There is no value that satisfies both:

- below ~500ms → the drag wins and the menu becomes unreachable
- at or above ~500ms → the menu wins and the drag never activates

We hit this shipping drag-to-reschedule in a planner app, where the same card is both a drag source and the host of a context menu carrying most of its actions. It presented as an *intermittent* menu, which took a while to pin down: the menu only appeared when the drag happened to fail first via `dragActivationFailOffset`.

`dragActivationFailOffset` can't express the alternative, because it applies one value to both `failOffsetX` and `failOffsetY`. Separating the gestures needs "activate on horizontal, fail on vertical" — which requires per-axis control.

## The fix

When every meaningful drop is on one axis, the offsets separate the three gestures cleanly, with no timer involved:

```jsx
<DraxView
  longPressDelay={0}                    // a stationary press never starts a drag
  dragActivationOffsetX={[-15, 15]}     // only a sideways pull picks the view up
  dragActivationFailOffsetY={[-15, 15]} // vertical travel returns the gesture to the list
  payload={item}
/>
```

A press that doesn't move leaves the context menu to open, a vertical drag scrolls the list, and a horizontal drag starts the drag. It also removes a footgun in the existing API: with `longPressDelay: 0`, a symmetric `dragActivationFailOffset` is the only rule the pan has left, so setting one prevents the drag from ever activating.

## Compatibility

Fully additive:

- every new prop is optional
- `dragActivationFailOffset` keeps its exact current meaning as the symmetric shorthand; the per-axis values take precedence only on their own axis, and only when set
- no behavior changes for any view that doesn't set the new props

## Changes

- `src/types.ts` — the four new `DraxViewProps`
- `src/DraxView.tsx` — added to `DRAX_PROP_KEYS` (so they don't reach the underlying `Reanimated.View`) and forwarded to `useDragGesture`
- `src/hooks/useDragGesture.ts` — one new optional trailing argument; per-axis values resolve over the symmetric shorthand
- `src/compat/types.ts`, `src/compat/useDraxPanGesture.ts` — `activeOffsetX` / `activeOffsetY` applied on **both** the RNGH v2 builder and v3 `usePanGesture` paths
- `docs-site/docs/api/components/drax-view.mdx` — props table rows plus a short "Activating a drag by direction" section

I left `CHANGELOG.md` alone since `release-it` looks like it's part of your release flow — glad to add an entry if you'd rather it came with the PR.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test` and `yarn prepare` all pass, as do the lefthook pre-commit hooks.

Beyond that it's been running in a production React Native app (iOS/iPad, Android, and web) via `patch-package`, on RNGH 2.32 and Reanimated 4.5, across roughly a dozen simultaneous drop targets in a scrollable container. Verified by hand that the context menu and the drag now coexist on iPad, which is what motivated the change.

I don't have a repro in `example/` — let me know if you'd like one added and I'll put it together.