### PR TITLE
fix: cross-container drop reverting to origin container on react-native-gesture-handler 3.x 

### DIFF
--- a/src/SortableBoardContainer.tsx
+++ b/src/SortableBoardContainer.tsx
@@ -365,6 +365,17 @@ export const SortableBoardContainer = <TItem,>({
       }
     }
 
+    // A cancelled drag-end arriving after the success path above has already
+    // run (source info cleared, transfer still pending for finalizeTransfer)
+    // is stale — reinjecting would revert the completed transfer. Return the
+    // phantom snap target again so the in-flight snap stays aimed at the
+    // target column instead of resolving to the default origin target.
+    if (cancelled && transfer?.targetId && !sourceInfoRef.current) {
+      draxViewProps?.onMonitorDragEnd?.(eventData);
+      const staleTarget = columns.get(transfer.targetId);
+      return staleTarget ? staleTarget.getPhantomSnapTarget() : undefined;
+    }
+
     if (transfer) {
       // Cancelled or no target — clear phantom and reinject
       if (transfer.targetId) {

--- a/src/compat/finalizeCanceled.ts
+++ b/src/compat/finalizeCanceled.ts
@@ -1,0 +1,16 @@
+import type { DraxPanEvent } from './types';
+
+/**
+ * Whether a finalized pan gesture was cancelled, across gesture-handler
+ * versions. Released v3 reports it as `event.canceled` (PR #3887); v2 and
+ * v3 betas predating that change pass a legacy `success` second parameter
+ * instead. Reading only the parameter makes every normal end look cancelled
+ * on released v3.
+ */
+export function isFinalizeCanceled(
+  event: DraxPanEvent,
+  didSucceed?: boolean
+): boolean {
+  'worklet';
+  return event.canceled ?? didSucceed === false;
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -1,4 +1,5 @@
 export { useDraxPanGesture } from './useDraxPanGesture';
+export { isFinalizeCanceled } from './finalizeCanceled';
 export type {
   DraxPanEvent,
   DraxPanGesture,

--- a/src/compat/types.ts
+++ b/src/compat/types.ts
@@ -13,6 +13,10 @@ export interface DraxPanEvent {
   y: number;
   absoluteX: number;
   absoluteY: number;
+  /** Released v3 (gesture-handler PR #3887) moved the end flag into the
+   *  event, inverted, replacing the legacy `success` second parameter.
+   *  Absent on v2 and on v3 betas before the change. */
+  canceled?: boolean;
 }
 
 /** Config for the version-agnostic pan gesture hook. */
@@ -31,5 +35,7 @@ export interface DraxPanGestureConfig {
   onActivate: (event: DraxPanEvent) => void;
   onUpdate: (event: DraxPanEvent) => void;
   onDeactivate: (event: DraxPanEvent) => void;
-  onFinalize: (event: DraxPanEvent, didSucceed: boolean) => void;
+  /** `didSucceed` is only passed by v2 and by v3 betas predating
+   *  gesture-handler PR #3887; released v3 sends `event.canceled` instead. */
+  onFinalize: (event: DraxPanEvent, didSucceed?: boolean) => void;
 }

--- a/src/hooks/useDragGesture.ts
+++ b/src/hooks/useDragGesture.ts
@@ -2,7 +2,7 @@ import { Platform } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import { runOnJS } from 'react-native-worklets';
 
-import { useDraxPanGesture } from '../compat';
+import { isFinalizeCanceled, useDraxPanGesture } from '../compat';
 import { computeAbsolutePositionWorklet, hitTestWorklet } from '../math';
 import type { Position } from '../types';
 import { useDraxContext } from './useDraxContext';
@@ -239,13 +239,13 @@ export const useDragGesture = (
       // Bounce to JS for end callbacks + snap animation
       runOnJS(handleDragEnd)(currentDraggedId, currentReceiverId, false, finalHitResult.monitorIds);
     },
-    onFinalize: (_event, didSucceed) => {
+    onFinalize: (event, didSucceed) => {
       'worklet';
 
       // If gesture was cancelled (not ended normally).
       // Check draggedIdSV (set in onActivate) instead of dragPhaseSV
       // because phase is now set later in handleDragStart via runOnUI.
-      if (!didSucceed && draggedIdSV.value !== '') {
+      if (isFinalizeCanceled(event, didSucceed) && draggedIdSV.value !== '') {
         const currentDraggedId = draggedIdSV.value;
         const currentReceiverId = receiverIdSV.value;
 


### PR DESCRIPTION
[RNGH PR #3887](https://github.com/software-mansion/react-native-gesture-handler/pull/3887) moved the end flag from onFinalize's legacy `success` second parameter into the event itself, inverted as `canceled`.

The v3 gesture path still read the removed parameter, so on 3.x every normally-ended drag finalized as cancelled

I think this wasn't found before because the demos are all pinned to  react-native-guesture-handler 3.0.0-beta.2, when I upgraded them to either 3.0.1 and 3.1.0 the [cross-list demo](https://nuclearpasta.com/react-native-drax/example/cross-list) fails.

I added code in `./compat` to  normalize the API as best I could, but I can remove it and lock to 3.x if you'd like to make a clean break.

If you'd like I can also contribute a test as well.