### PR TITLE
fix(sortable): make onItemSnapEnd a ref so finalizeDrag is actually called

### DIFF
--- a/docs-site/docs/api/components/sortable-item.mdx
+++ b/docs-site/docs/api/components/sortable-item.mdx
@@ -102,7 +102,7 @@ Returns: `itemKey`, `index`, `isActive` (SharedValue), `activeItemId` (SharedVal
 - Shift values come from `shiftsRef` SharedValue (keyed by item key)
 - Visibility controlled by `hoverReadySV` + `draggedIdSV` — hidden when being dragged
 - Measures itself on layout and stores in `itemMeasurements` Map
-- Calls `onItemSnapEnd` when snap-back completes (triggers reorder finalization)
+- Calls `onItemSnapEndRef.current` when snap-back completes (triggers reorder finalization)
 - Respects reduced motion via `useReducedMotion()`
 
 ## Related

--- a/docs-site/versioned_docs/version-1.x/api/components/sortable-item.mdx
+++ b/docs-site/versioned_docs/version-1.x/api/components/sortable-item.mdx
@@ -102,7 +102,7 @@ Returns: `itemKey`, `index`, `isActive` (SharedValue), `activeItemId` (SharedVal
 - Shift values come from `shiftsRef` SharedValue (keyed by item key)
 - Visibility controlled by `hoverReadySV` + `draggedIdSV` — hidden when being dragged
 - Measures itself on layout and stores in `itemMeasurements` Map
-- Calls `onItemSnapEnd` when snap-back completes (triggers reorder finalization)
+- Calls `onItemSnapEndRef.current` when snap-back completes (triggers reorder finalization)
 - Respects reduced motion via `useReducedMotion()`
 
 ## Related

--- a/src/SortableContainer.tsx
+++ b/src/SortableContainer.tsx
@@ -214,7 +214,7 @@ export const SortableContainer = ({
   // calls the latest version, even if it has a stale _internal reference
   // (e.g., after MATCH path skips FlatList re-render).
   useLayoutEffect(() => {
-    sortable._internal.onItemSnapEnd = finalizeDrag;
+    sortable._internal.onItemSnapEndRef.current = finalizeDrag;
   }, [sortable._internal, finalizeDrag]);
 
   // ── Auto-scroll ─────────────────────────────────────────────────────

--- a/src/SortableItem.tsx
+++ b/src/SortableItem.tsx
@@ -126,7 +126,7 @@ const SortableItemInner = ({
     rawData,
     originalIndexes,
     scrollPosition,
-    onItemSnapEnd,
+    onItemSnapEndRef,
     fixedKeys,
   } = sortable._internal;
 
@@ -221,7 +221,7 @@ const SortableItemInner = ({
           draxViewProps.onDragDrop?.(event);
         }}
         onSnapEnd={(snapData) => {
-          onItemSnapEnd?.();
+          onItemSnapEndRef.current?.();
           draxViewProps.onSnapEnd?.(snapData);
         }}
         onMeasure={(measurements) => {

--- a/src/hooks/useSortableList.ts
+++ b/src/hooks/useSortableList.ts
@@ -122,6 +122,13 @@ export const useSortableList = <T,>(
   const draggedDisplayIndexRef = useRef<number | undefined>(undefined);
   const dragStartIndexRef = useRef<number | undefined>(undefined);
   /**
+   * Holds the `finalizeDrag` callback registered by `SortableContainer`.
+   * A ref (not a plain property) so `SortableItem` reads the latest value at
+   * call time — `_internal` is rebuilt every render, so a value stored on it
+   * directly is always `undefined` for consumers that destructure at render.
+   */
+  const onItemSnapEndRef = useRef<(() => void) | undefined>(undefined);
+  /**
    * Pending reorder during drag. Tracks the desired display order
    * as indices into rawData. Updated by moveDraggedItem (ref, not state).
    */
@@ -1023,7 +1030,7 @@ export const useSortableList = <T,>(
     getMeasurementByOriginalIndex,
     dropTargetPositionSV,
     dropTargetVisibleSV,
-    onItemSnapEnd: undefined as (() => void) | undefined,
+    onItemSnapEndRef,
     draggedDisplayIndexRef,
     dragStartIndexRef,
     shiftsRef,

--- a/src/types.ts
+++ b/src/types.ts
@@ -812,7 +812,7 @@ export interface SortableListInternal<T> {
   /** Called by SortableItem's onSnapEnd to finalize the drag.
    *  Stored as a ref so the latest finalizeDrag is always called,
    *  even if SortableItem has a stale _internal reference. */
-  onItemSnapEnd?: () => void;
+  onItemSnapEndRef: RefObject<(() => void) | undefined>;
   /** Current display index of the dragged item (updated during live reorder) */
   draggedDisplayIndexRef: RefObject<number | undefined>;
   /** Original display index where the drag started */


### PR DESCRIPTION
Fixes #236.

## Problem

`SortableItem` destructures `onItemSnapEnd` from `sortable._internal` **at render time**:

```tsx
const { ..., onItemSnapEnd, ... } = sortable._internal;
```

but `SortableContainer` only assigns it in a `useLayoutEffect`, which runs **after** render:

```tsx
useLayoutEffect(() => {
  sortable._internal.onItemSnapEnd = finalizeDrag;
}, [sortable._internal, finalizeDrag]);
```

`useSortableList` rebuilds `_internal` on every render with `onItemSnapEnd: undefined`, so the value `SortableItem` captured is always `undefined` — the assignment from the previous render is written onto an object that has already been replaced.

Net effect: `finalizeDrag` is never called from `onSnapEnd`, the reorder is never committed, and the item visually snaps back to its original position after the drop.

## Why the previous approach could not work

The type already documented the intended semantics:

```ts
/** Called by SortableItem's onSnapEnd to finalize the drag.
 *  Stored as a ref so the latest finalizeDrag is always called,
 *  even if SortableItem has a stale _internal reference. */
```

That contract requires a stable identity across renders, which a plain property on a per-render object cannot provide. This PR makes it an actual ref.

## Change

- `useSortableList` now owns `onItemSnapEndRef` — a `useRef` created once, so its identity is stable for the lifetime of the hook.
- `SortableContainer` writes `sortable._internal.onItemSnapEndRef.current = finalizeDrag`.
- `SortableItem` calls `onItemSnapEndRef.current?.()` — read at **call time**, so it sees the registered callback no matter when `_internal` was captured.
- `SortableListInternal.onItemSnapEnd?: () => void` becomes `onItemSnapEndRef: RefObject<(() => void) | undefined>`.

Destructuring the ref in `SortableItem` is safe now precisely because the ref object is stable; only its `.current` changes.

This also covers the stale-`_internal` case the original comment was worried about (e.g. the MATCH path skipping a `FlatList` re-render): even a `SortableItem` holding an older `_internal` reaches the same ref object and therefore the latest `finalizeDrag`.

Note on the report in the issue thread that a one-line patch (`sortable._internal.onItemSnapEnd?.()`) did not fully help: that variant reads the *current render's* `_internal`, which has just been rebuilt with `undefined` and is only patched by the `useLayoutEffect` afterwards — so it still misses depending on timing. The ref removes the ordering dependency entirely.

`SortableListInternal` is an internal type (`_internal`), so this is not a public API change.

## Validation

```
yarn typecheck   # tsc + example tsconfig — clean
yarn lint        # eslint — clean
yarn test        # jest — no tests in repo, passes
yarn prepare     # bob build — module + typescript definitions written OK
```

I also updated the two `sortable-item.mdx` architecture notes that referenced the old name so the docs match the code.
